### PR TITLE
Fix broken tailwind style import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-node_modules
+.idea
 .DS_Store
+node_modules
 dist

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
# Context
According to [v4 docs](https://tailwindcss.com/docs/installation/using-vite) it's advised to use `@import "tailwindcss";`. I've also added `.idea` to the `.gitignore`.